### PR TITLE
Fix error reporting from custom transpilation passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Always raise `QiskitError` on errors in the custom transpilation passes #57
+* Always raise `TranspilerError` on errors in the custom transpilation passes #57
 
 ## qiskit-aqt-provider v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Always raise `QiskitError` on errors in the custom transpilation passes #57
+
 ## qiskit-aqt-provider v0.12.0
 
 * Use `ruff` instead of `pylint` as linter #51

--- a/qiskit_aqt_provider/transpiler_plugin.py
+++ b/qiskit_aqt_provider/transpiler_plugin.py
@@ -12,7 +12,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Callable, List, Literal, Optional, Tuple, Type, Union, overload
+from typing import List, Optional, Tuple
 
 import numpy as np
 from qiskit import QuantumCircuit
@@ -27,60 +27,7 @@ from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
 
-
-@overload
-def with_qiskit_error(
-    run_func: Literal[None], /, exc_types: Tuple[Type[BaseException], ...] = ...
-) -> Callable[
-    [Callable[[TransformationPass, DAGCircuit], DAGCircuit]],
-    Callable[[TransformationPass, DAGCircuit], DAGCircuit],
-]:
-    ...  # pragma: no cover
-
-
-@overload
-def with_qiskit_error(
-    run_func: Callable[[BasePass, DAGCircuit], DAGCircuit],
-    /,
-    exc_types: Tuple[Type[BaseException], ...] = ...,
-) -> Callable[[BasePass, DAGCircuit], DAGCircuit]:
-    ...  # pragma: no cover
-
-
-def with_qiskit_error(
-    run_func: Optional[Callable[[BasePass, DAGCircuit], DAGCircuit]] = None,
-    /,
-    exc_types: Tuple[Type[BaseException], ...] = (Exception,),
-) -> Union[
-    Callable[
-        [Callable[[BasePass, DAGCircuit], DAGCircuit]],
-        Callable[[BasePass, DAGCircuit], DAGCircuit],
-    ],
-    Callable[[BasePass, DAGCircuit], DAGCircuit],
-]:
-    """Decorator for `BasePass.run` methods to raise `QiskitError` on execution errors.
-
-    Args:
-        run_func: method to decorate. If none, act as a decorator factory
-        exc_types: which error types to re-raise as `QiskitError`.
-    """
-    # TODO: use ParamSpec once py310 is the lowest supported version
-
-    def impl(
-        func: Callable[[BasePass, DAGCircuit], DAGCircuit]
-    ) -> Callable[[BasePass, DAGCircuit], DAGCircuit]:
-        def wrapper(self: BasePass, dag: DAGCircuit) -> DAGCircuit:
-            try:
-                return func(self, dag)
-            except exc_types as e:
-                raise QiskitError from e
-
-        return wrapper
-
-    if run_func is not None:
-        return impl(run_func)
-
-    return impl  # pragma: no cover
+from qiskit_aqt_provider.utils import map_exceptions
 
 
 def rewrite_rx_as_r(theta: float) -> Instruction:
@@ -93,7 +40,7 @@ def rewrite_rx_as_r(theta: float) -> Instruction:
 class RewriteRxAsR(TransformationPass):
     """Rewrite Rx(θ) as R(θ, φ) with θ ∈ [0, π] and φ ∈ [0, 2π]."""
 
-    @with_qiskit_error
+    @map_exceptions(QiskitError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rx":
@@ -184,7 +131,7 @@ def wrap_rxx_angle(theta: float) -> Instruction:
 class WrapRxxAngles(TransformationPass):
     """Wrap Rxx angles to [-π/2, π/2]."""
 
-    @with_qiskit_error
+    @map_exceptions(QiskitError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rxx":

--- a/qiskit_aqt_provider/transpiler_plugin.py
+++ b/qiskit_aqt_provider/transpiler_plugin.py
@@ -20,8 +20,8 @@ from qiskit.circuit import Gate, Instruction
 from qiskit.circuit.library import RGate, RXGate, RXXGate, RZGate
 from qiskit.circuit.tools import pi_check
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.exceptions import QiskitError
 from qiskit.transpiler.basepasses import BasePass, TransformationPass
+from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import common
@@ -40,7 +40,7 @@ def rewrite_rx_as_r(theta: float) -> Instruction:
 class RewriteRxAsR(TransformationPass):
     """Rewrite Rx(θ) as R(θ, φ) with θ ∈ [0, π] and φ ∈ [0, 2π]."""
 
-    @map_exceptions(QiskitError)
+    @map_exceptions(TranspilerError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rx":
@@ -131,7 +131,7 @@ def wrap_rxx_angle(theta: float) -> Instruction:
 class WrapRxxAngles(TransformationPass):
     """Wrap Rxx angles to [-π/2, π/2]."""
 
-    @map_exceptions(QiskitError)
+    @map_exceptions(TranspilerError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rxx":

--- a/qiskit_aqt_provider/utils.py
+++ b/qiskit_aqt_provider/utils.py
@@ -1,0 +1,64 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from typing import Callable, Tuple, Type, TypeVar
+
+from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def map_exceptions(
+    target_exc: Type[BaseException], /, *, source_exc: Tuple[Type[BaseException]] = (Exception,)
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Map select exceptions to another exception type.
+
+    Args:
+        target_exc: exception type to map to
+        source_exc: exception types to map to `target_exc`
+
+    Examples:
+        >>> @map_exceptions(ValueError)
+        ... def func() -> None:
+        ...     raise TypeError
+        ...
+
+        >>> func()  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        ValueError
+
+        is equivalent to:
+
+        >>> def func() -> None:
+        ...     raise TypeError
+        ...
+        >>> try:
+        ...     func()
+        ... except Exception as e:
+        ...     raise ValueError from e
+        Traceback (most recent call last):
+        ...  # doctest: +ELLIPSIS
+        ValueError
+    """
+
+    def impl(func: Callable[P, T]) -> Callable[P, T]:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            try:
+                return func(*args, **kwargs)
+            except source_exc as e:
+                raise target_exc from e
+
+        return wrapper
+
+    return impl

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -1,0 +1,83 @@
+# This code is part of Qiskit.
+#
+# (C) Alpine Quantum Technologies GmbH 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import importlib.metadata
+from math import pi
+from typing import Callable
+
+import pytest
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.exceptions import QiskitError
+from qiskit.primitives import BackendSampler, BaseSampler, Sampler
+from qiskit.providers import Backend
+
+from qiskit_aqt_provider.aqt_resource import AQTResource
+
+
+@pytest.mark.skipif(
+    importlib.metadata.version("qiskit-terra") >= "0.24.0",
+    reason="qiskit.opflow is deprecated in qiskit-terra>=0.24",
+)
+def test_circuit_sampling_opflow(offline_simulator_no_noise: AQTResource) -> None:
+    """Check that an `AQTResource` can be used as backend for the legacy
+    `opflow.CircuitSampler` with parametric circuits.
+    """
+    from qiskit.opflow import CircuitSampler, StateFn
+
+    theta = Parameter("θ")
+
+    qc = QuantumCircuit(2)
+    qc.rx(theta, 0)
+    qc.ry(theta, 0)
+    qc.rz(theta, 0)
+    qc.rxx(theta, 0, 1)
+
+    assert qc.num_parameters > 0
+
+    sampler = CircuitSampler(offline_simulator_no_noise)
+
+    sampled = sampler.convert(StateFn(qc), params={theta: pi}).eval()
+    assert sampled.to_matrix().tolist() == [[0.0, 0.0, 0.0, 1.0]]
+
+
+@pytest.mark.parametrize(
+    "get_sampler",
+    [
+        lambda _: Sampler(),
+        # The AQT transpilation plugin doesn't support transpiling unbound parametric circuits
+        # and the BackendSampler doesn't fallback to transpiling the bound circuit if
+        # transpiling the unbound circuit failed (like the opflow sampler does).
+        # Sampling a parametric circuit with an AQT backend is therefore not supported.
+        pytest.param(
+            lambda backend: BackendSampler(backend), marks=pytest.mark.xfail(raises=QiskitError)
+        ),
+    ],
+)
+def test_circuit_sampling_primitive(
+    get_sampler: Callable[[Backend], BaseSampler],
+    offline_simulator_no_noise: AQTResource,
+) -> None:
+    """Check that a `Sampler` primitive using an AQT backend can sample parametric circuits."""
+    theta = Parameter("θ")
+
+    qc = QuantumCircuit(2)
+    qc.rx(theta, 0)
+    qc.ry(theta, 0)
+    qc.rz(theta, 0)
+    qc.rxx(theta, 0, 1)
+    qc.measure_all()
+
+    assert qc.num_parameters > 0
+
+    sampler = get_sampler(offline_simulator_no_noise)
+    sampled = sampler.run(qc, [pi]).result().quasi_dists
+    assert sampled == [{3: 1.0}]

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -16,9 +16,9 @@ from typing import Callable
 
 import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.exceptions import QiskitError
 from qiskit.primitives import BackendSampler, BaseSampler, Sampler
 from qiskit.providers import Backend
+from qiskit.transpiler.exceptions import TranspilerError
 
 from qiskit_aqt_provider.aqt_resource import AQTResource
 
@@ -58,7 +58,7 @@ def test_circuit_sampling_opflow(offline_simulator_no_noise: AQTResource) -> Non
         # transpiling the unbound circuit failed (like the opflow sampler does).
         # Sampling a parametric circuit with an AQT backend is therefore not supported.
         pytest.param(
-            lambda backend: BackendSampler(backend), marks=pytest.mark.xfail(raises=QiskitError)
+            lambda backend: BackendSampler(backend), marks=pytest.mark.xfail(raises=TranspilerError)
         ),
     ],
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Wrap the transformation functions of the custom transpilation passes such that any error is reported as `TranspilerError` (a subclass of `QiskitError`).

This increases the compliance of the custom transpilation passes with the rest of the Qiskit infrastructure, in particular the legacy `qiskit.opflow` tools.

### Details and comments

- the legacy `qiskit.opflow.CircuitSampler` tool is able to deal with failures of the transpiler for unbound parametric circuits by [delaying transpilation](https://github.com/Qiskit/qiskit-terra/blob/601bd9a132ee96edf2ac6b0dc164a0d2a2f61861/qiskit/opflow/converters/circuit_sampler.py#L300-L311) after the parameters are bound. This is unfortunately not the case for the new `BackendSampler`.