### PR TITLE
Add specialized Sampler primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Always raise `TranspilerError` on errors in the custom transpilation passes #57
+* Add `AQTSampler`, a specialized implementation of the `Sampler` primitive #60
 
 ## qiskit-aqt-provider v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Always raise `QiskitError` on errors in the custom transpilation passes #57
+* Always raise `TranspilerError` on errors in the custom transpilation passes #57
 
 ## qiskit-aqt-provider v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Always raise `QiskitError` on errors in the custom transpilation passes #57
+
 ## qiskit-aqt-provider v0.12.0
 
 * Use `ruff` instead of `pylint` as linter #51

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ target-version = 'py38'
 convention = "google"
 
 [tool.coverage.report]
-fail_under = 96
+fail_under = 97
 
 [tool.poe.tasks.test]
 shell = """

--- a/qiskit_aqt_provider/primitives/__init__.py
+++ b/qiskit_aqt_provider/primitives/__init__.py
@@ -1,0 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from .sampler import AQTSampler
+
+__all__ = ["AQTSampler"]

--- a/qiskit_aqt_provider/primitives/sampler.py
+++ b/qiskit_aqt_provider/primitives/sampler.py
@@ -1,0 +1,75 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from copy import copy
+from typing import Any, Dict, Optional
+
+from qiskit.primitives import BackendSampler
+from qiskit.transpiler.passes import Decompose, Optimize1qGatesDecomposition
+from qiskit.transpiler.passmanager import PassManager
+
+from qiskit_aqt_provider import transpiler_plugin
+from qiskit_aqt_provider.aqt_resource import AQTResource, make_transpiler_target
+
+
+class AQTSampler(BackendSampler):
+    """Sampler primitive for AQT backends."""
+
+    _backend: AQTResource
+
+    def __init__(
+        self,
+        backend: AQTResource,
+        options: Optional[Dict[str, Any]] = None,
+        skip_transpilation: bool = False,
+    ):
+        """Initialize a Sampler primitive for AQT resources.
+
+        Args:
+            backend: AQT resource to evaluate circuits on
+            options: options passed to the base sampler
+            skip_transpilation: if true, pass circuits unchanged to the backend.
+        """
+        # Signal the transpiler to disable passes that require bound
+        # parameters.
+        # This allows the underlying sampler to apply most of
+        # the transpilation passes, and cache the results.
+        mod_backend = copy(backend)
+        mod_backend._target = make_transpiler_target(
+            transpiler_plugin.UnboundParametersTarget, backend.num_qubits
+        )
+
+        # Wrap the gate angles after the parameters are bound.
+        bound_pass_manager = PassManager(
+            [
+                # wrap the Rxx angles
+                transpiler_plugin.WrapRxxAngles(),
+                # decompose the substituted Rxx gates
+                Decompose([f"{transpiler_plugin.WrapRxxAngles.SUBSTITUTE_GATE_NAME}*"]),
+                # collapse the single qubit runs as ZXZ
+                Optimize1qGatesDecomposition(target=mod_backend.target),
+                # wrap the Rx angles, rewrite as R
+                transpiler_plugin.RewriteRxAsR(),
+            ]
+        )
+
+        super().__init__(
+            mod_backend,
+            bound_pass_manager=bound_pass_manager,
+            options=options,
+            skip_transpilation=skip_transpilation,
+        )
+
+    @property
+    def backend(self) -> AQTResource:
+        """Computing resource used for circuit evaluation."""
+        return self._backend

--- a/qiskit_aqt_provider/test/fixtures.py
+++ b/qiskit_aqt_provider/test/fixtures.py
@@ -15,31 +15,48 @@
 This module is exposed as pytest plugin for this project.
 """
 
-from typing import Iterator
-from unittest.mock import patch
+from typing import Iterator, List, Tuple
 
 import pytest
+from qiskit.circuit import QuantumCircuit
 
 from qiskit_aqt_provider.aqt_provider import AQTProvider
-from qiskit_aqt_provider.aqt_resource import AQTResource, OfflineSimulatorResource
+from qiskit_aqt_provider.aqt_resource import ApiResource, OfflineSimulatorResource
 from qiskit_aqt_provider.circuit_to_aqt import circuit_to_aqt
 
 
+class MockSimulator(OfflineSimulatorResource):
+    """Offline simulator that keeps track of the submitted circuits."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            AQTProvider(""),
+            "default",
+            ApiResource(name="mock_simulator", id="mock_simulator", type="offline_simulator"),
+        )
+
+        self.submit_call_args: List[Tuple[QuantumCircuit, int]] = []
+
+    def submit(self, circuit: QuantumCircuit, shots: int) -> str:
+        self.submit_call_args.append((circuit, shots))
+        return super().submit(circuit, shots)
+
+    @property
+    def submitted_circuits(self) -> List[QuantumCircuit]:
+        """Circuits passed to the resource for execution, in submission order."""
+        return [circuit for circuit, _ in self.submit_call_args]
+
+
 @pytest.fixture(name="offline_simulator_no_noise")
-def fixture_offline_simulator_no_noise() -> Iterator[AQTResource]:
+def fixture_offline_simulator_no_noise() -> Iterator[MockSimulator]:
     """Noiseless offline simulator resource."""
-    provider = AQTProvider("")
-    resource = provider.get_resource("default", "offline_simulator_no_noise")
-    with patch.object(OfflineSimulatorResource, "submit", wraps=resource.submit) as mock:
-        yield resource
+    resource = MockSimulator()
+    yield resource
 
-        # try to convert all circuits that were passed to the simulator
-        # to the AQT API JSON format.
-        for call_args in mock.call_args_list:
-            # this could fail if submit() is (partially or fully) called with kwargs
-            circuit, shots = call_args.args
-
-            try:
-                _ = circuit_to_aqt(circuit, shots=shots)
-            except Exception:  # pragma: no cover  # noqa: BLE001
-                pytest.fail(f"Circuit cannot be converted to the AQT JSON format:\n{circuit}")
+    # try to convert all circuits that were passed to the simulator
+    # to the AQT API JSON format.
+    for circuit, shots in resource.submit_call_args:
+        try:
+            _ = circuit_to_aqt(circuit, shots=shots)
+        except Exception:  # pragma: no cover  # noqa: BLE001
+            pytest.fail(f"Circuit cannot be converted to the AQT JSON format:\n{circuit}")

--- a/qiskit_aqt_provider/transpiler_plugin.py
+++ b/qiskit_aqt_provider/transpiler_plugin.py
@@ -12,7 +12,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Callable, List, Literal, Optional, Tuple, Type, Union, overload
+from typing import List, Optional, Tuple
 
 import numpy as np
 from qiskit import QuantumCircuit
@@ -27,60 +27,7 @@ from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
 
-
-@overload
-def with_qiskit_error(
-    run_func: Literal[None], /, exc_types: Tuple[Type[BaseException], ...] = ...
-) -> Callable[
-    [Callable[[TransformationPass, DAGCircuit], DAGCircuit]],
-    Callable[[TransformationPass, DAGCircuit], DAGCircuit],
-]:
-    ...  # pragma: no cover
-
-
-@overload
-def with_qiskit_error(
-    run_func: Callable[[BasePass, DAGCircuit], DAGCircuit],
-    /,
-    exc_types: Tuple[Type[BaseException], ...] = ...,
-) -> Callable[[BasePass, DAGCircuit], DAGCircuit]:
-    ...  # pragma: no cover
-
-
-def with_qiskit_error(
-    run_func: Optional[Callable[[BasePass, DAGCircuit], DAGCircuit]] = None,
-    /,
-    exc_types: Tuple[Type[BaseException], ...] = (Exception,),
-) -> Union[
-    Callable[
-        [Callable[[BasePass, DAGCircuit], DAGCircuit]],
-        Callable[[BasePass, DAGCircuit], DAGCircuit],
-    ],
-    Callable[[BasePass, DAGCircuit], DAGCircuit],
-]:
-    """Decorator for `BasePass.run` methods to raise `QiskitError` on execution errors.
-
-    Args:
-        run_func: method to decorate. If none, act as a decorator factory
-        exc_types: which error types to re-raise as `QiskitError`.
-    """
-    # TODO: use ParamSpec once py310 is the lowest supported version
-
-    def impl(
-        func: Callable[[BasePass, DAGCircuit], DAGCircuit]
-    ) -> Callable[[BasePass, DAGCircuit], DAGCircuit]:
-        def wrapper(self: BasePass, dag: DAGCircuit) -> DAGCircuit:
-            try:
-                return func(self, dag)
-            except exc_types as e:
-                raise QiskitError from e
-
-        return wrapper
-
-    if run_func is not None:
-        return impl(run_func)
-
-    return impl  # pragma: no cover
+from qiskit_aqt_provider.utils import map_exceptions
 
 
 def rewrite_rx_as_r(theta: float) -> Instruction:
@@ -93,7 +40,7 @@ def rewrite_rx_as_r(theta: float) -> Instruction:
 class RewriteRxAsR(TransformationPass):
     """Rewrite Rx(θ) as R(θ, φ) with θ ∈ [0, π] and φ ∈ [0, 2π]."""
 
-    @with_qiskit_error
+    @map_exceptions(QiskitError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rx":
@@ -184,7 +131,7 @@ def wrap_rxx_angle(theta: float) -> Instruction:
 class WrapRxxAngles(TransformationPass):
     """Wrap Rxx angles to [-π/2, π/2]."""
 
-    @with_qiskit_error
+    @map_exceptions(QiskitError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rxx":

--- a/qiskit_aqt_provider/transpiler_plugin.py
+++ b/qiskit_aqt_provider/transpiler_plugin.py
@@ -20,8 +20,8 @@ from qiskit.circuit import Gate, Instruction
 from qiskit.circuit.library import RGate, RXGate, RXXGate, RZGate
 from qiskit.circuit.tools import pi_check
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.exceptions import QiskitError
 from qiskit.transpiler.basepasses import BasePass, TransformationPass
+from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import common
@@ -40,7 +40,7 @@ def rewrite_rx_as_r(theta: float) -> Instruction:
 class RewriteRxAsR(TransformationPass):
     """Rewrite Rx(θ) as R(θ, φ) with θ ∈ [0, π] and φ ∈ [0, 2π]."""
 
-    @map_exceptions(QiskitError)
+    @map_exceptions(TranspilerError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rx":
@@ -131,7 +131,7 @@ def wrap_rxx_angle(theta: float) -> Instruction:
 class WrapRxxAngles(TransformationPass):
     """Wrap Rxx angles to [-π/2, π/2]."""
 
-    @map_exceptions(QiskitError)
+    @map_exceptions(TranspilerError)
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         for node in dag.gate_nodes():
             if node.name == "rxx":

--- a/qiskit_aqt_provider/utils.py
+++ b/qiskit_aqt_provider/utils.py
@@ -1,0 +1,64 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright Alpine Quantum Technologies GmbH 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from typing import Callable, Tuple, Type, TypeVar
+
+from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def map_exceptions(
+    target_exc: Type[BaseException], /, *, source_exc: Tuple[Type[BaseException]] = (Exception,)
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Map select exceptions to another exception type.
+
+    Args:
+        target_exc: exception type to map to
+        source_exc: exception types to map to `target_exc`
+
+    Examples:
+        >>> @map_exceptions(ValueError)
+        ... def func() -> None:
+        ...     raise TypeError
+        ...
+
+        >>> func()  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        ValueError
+
+        is equivalent to:
+
+        >>> def func() -> None:
+        ...     raise TypeError
+        ...
+        >>> try:
+        ...     func()
+        ... except Exception as e:
+        ...     raise ValueError from e
+        Traceback (most recent call last):
+        ...  # doctest: +ELLIPSIS
+        ValueError
+    """
+
+    def impl(func: Callable[P, T]) -> Callable[P, T]:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            try:
+                return func(*args, **kwargs)
+            except source_exc as e:
+                raise target_exc from e
+
+        return wrapper
+
+    return impl

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -1,0 +1,83 @@
+# This code is part of Qiskit.
+#
+# (C) Alpine Quantum Technologies GmbH 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import importlib.metadata
+from math import pi
+from typing import Callable
+
+import pytest
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.exceptions import QiskitError
+from qiskit.primitives import BackendSampler, BaseSampler, Sampler
+from qiskit.providers import Backend
+
+from qiskit_aqt_provider.aqt_resource import AQTResource
+
+
+@pytest.mark.skipif(
+    importlib.metadata.version("qiskit-terra") >= "0.24.0",
+    reason="qiskit.opflow is deprecated in qiskit-terra>=0.24",
+)
+def test_circuit_sampling_opflow(offline_simulator_no_noise: AQTResource) -> None:
+    """Check that an `AQTResource` can be used as backend for the legacy
+    `opflow.CircuitSampler` with parametric circuits.
+    """
+    from qiskit.opflow import CircuitSampler, StateFn
+
+    theta = Parameter("θ")
+
+    qc = QuantumCircuit(2)
+    qc.rx(theta, 0)
+    qc.ry(theta, 0)
+    qc.rz(theta, 0)
+    qc.rxx(theta, 0, 1)
+
+    assert qc.num_parameters > 0
+
+    sampler = CircuitSampler(offline_simulator_no_noise)
+
+    sampled = sampler.convert(StateFn(qc), params={theta: pi}).eval()
+    assert sampled.to_matrix().tolist() == [[0.0, 0.0, 0.0, 1.0]]
+
+
+@pytest.mark.parametrize(
+    "get_sampler",
+    [
+        lambda _: Sampler(),
+        # The AQT transpilation plugin doesn't support transpiling unbound parametric circuits
+        # and the BackendSampler doesn't fallback to transpiling the bound circuit if
+        # transpiling the unbound circuit failed (like the opflow sampler does).
+        # Sampling a parametric circuit with an AQT backend is therefore not supported.
+        pytest.param(
+            lambda backend: BackendSampler(backend), marks=pytest.mark.xfail(raises=QiskitError)
+        ),
+    ],
+)
+def test_circuit_sampling_primitive(
+    get_sampler: Callable[[Backend], BaseSampler],
+    offline_simulator_no_noise: AQTResource,
+) -> None:
+    """Check that a `Sampler` primitive using an AQT backend can sample parametric circuits."""
+    theta = Parameter("θ")
+
+    qc = QuantumCircuit(2)
+    qc.rx(theta, 0)
+    qc.ry(theta, 0)
+    qc.rz(theta, 0)
+    qc.rxx(theta, 0, 1)
+    qc.measure_all()
+
+    assert qc.num_parameters > 0
+
+    sampler = get_sampler(offline_simulator_no_noise)
+    sampled = sampler.run(qc, [pi]).result().quasi_dists
+    assert sampled == [{3: 1.0}]

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -15,12 +15,15 @@ from math import pi
 from typing import Callable
 
 import pytest
+import qiskit
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.primitives import BackendSampler, BaseSampler, Sampler
 from qiskit.providers import Backend
 from qiskit.transpiler.exceptions import TranspilerError
 
 from qiskit_aqt_provider.aqt_resource import AQTResource
+from qiskit_aqt_provider.primitives import AQTSampler
+from qiskit_aqt_provider.test.circuits import assert_circuits_equal
 
 
 @pytest.mark.skipif(
@@ -52,14 +55,18 @@ def test_circuit_sampling_opflow(offline_simulator_no_noise: AQTResource) -> Non
 @pytest.mark.parametrize(
     "get_sampler",
     [
+        # Reference implementation
         lambda _: Sampler(),
         # The AQT transpilation plugin doesn't support transpiling unbound parametric circuits
         # and the BackendSampler doesn't fallback to transpiling the bound circuit if
         # transpiling the unbound circuit failed (like the opflow sampler does).
-        # Sampling a parametric circuit with an AQT backend is therefore not supported.
+        # Sampling a parametric circuit with the generic BackendSampler is therefore not supported.
         pytest.param(
             lambda backend: BackendSampler(backend), marks=pytest.mark.xfail(raises=TranspilerError)
         ),
+        # The specialized implementation of the Sampler primitive for AQT backends delays the
+        # transpilation passes that require bound parameters.
+        lambda backend: AQTSampler(backend),
     ],
 )
 def test_circuit_sampling_primitive(
@@ -81,3 +88,48 @@ def test_circuit_sampling_primitive(
     sampler = get_sampler(offline_simulator_no_noise)
     sampled = sampler.run(qc, [pi]).result().quasi_dists
     assert sampled == [{3: 1.0}]
+
+
+@pytest.mark.parametrize(
+    "theta",
+    [
+        pi / 3,
+        -pi / 3,
+        pi / 2,
+        -pi / 2,
+        3 * pi / 4,
+        -3 * pi / 4,
+        15 * pi / 8,
+        -15 * pi / 8,
+        33 * pi / 16,
+        -33 * pi / 16,
+    ],
+)
+def test_aqt_sampler_transpilation(theta: float, offline_simulator_no_noise: AQTResource) -> None:
+    """Check that the AQTSampler passes the same circuit to the backend as a call to
+    `qiskit.execute` with the same transpiler call on the bound circuit would.
+    """
+    theta_param = Parameter("θ")
+
+    # define a circuit with unbound parameters
+    qc = QuantumCircuit(2)
+    qc.rx(pi / 3, 0)
+    qc.rxx(theta_param, 0, 1)
+    qc.measure_all()
+
+    assert qc.num_parameters > 0
+
+    # sample the circuit, passing parameter assignments
+    sampler = AQTSampler(offline_simulator_no_noise)
+    sampler.run(qc, [theta]).result()
+
+    # the sampler was only called once
+    assert len(offline_simulator_no_noise.submitted_circuits) == 1
+    # get the circuit passed to the backend
+    (transpiled_circuit,) = offline_simulator_no_noise.submitted_circuits
+
+    # compare to the circuit obtained by binding the parameters and transpiling at once
+    expected = qc.assign_parameters({theta_param: theta})
+    tr_expected = qiskit.transpile(expected, offline_simulator_no_noise)
+
+    assert_circuits_equal(transpiled_circuit, tr_expected)

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -24,6 +24,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit_aqt_provider.aqt_resource import AQTResource
 from qiskit_aqt_provider.primitives import AQTSampler
 from qiskit_aqt_provider.test.circuits import assert_circuits_equal
+from qiskit_aqt_provider.test.fixtures import MockSimulator
 
 
 @pytest.mark.skipif(
@@ -105,7 +106,7 @@ def test_circuit_sampling_primitive(
         -33 * pi / 16,
     ],
 )
-def test_aqt_sampler_transpilation(theta: float, offline_simulator_no_noise: AQTResource) -> None:
+def test_aqt_sampler_transpilation(theta: float, offline_simulator_no_noise: MockSimulator) -> None:
     """Check that the AQTSampler passes the same circuit to the backend as a call to
     `qiskit.execute` with the same transpiler call on the bound circuit would.
     """

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -16,9 +16,9 @@ from typing import Callable
 
 import pytest
 from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.exceptions import QiskitError
 from qiskit.primitives import BackendSampler, BaseSampler, Sampler
 from qiskit.providers import Backend
+from qiskit.transpiler.exceptions import TranspilerError
 
 from qiskit_aqt_provider.aqt_resource import AQTResource
 
@@ -58,7 +58,7 @@ def test_circuit_sampling_opflow(offline_simulator_no_noise: AQTResource) -> Non
         # transpiling the unbound circuit failed (like the opflow sampler does).
         # Sampling a parametric circuit with an AQT backend is therefore not supported.
         pytest.param(
-            lambda backend: BackendSampler(backend), marks=pytest.mark.xfail(raises=QiskitError)
+            lambda backend: BackendSampler(backend), marks=pytest.mark.xfail(raises=TranspilerError)
         ),
     ],
 )

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -28,6 +28,7 @@ from qiskit_aqt_provider.aqt_resource import (
     OfflineSimulatorResource,
 )
 from qiskit_aqt_provider.test.circuits import empty_circuit
+from qiskit_aqt_provider.test.fixtures import MockSimulator
 from qiskit_aqt_provider.test.resources import DummyResource, TestResource
 
 
@@ -244,3 +245,18 @@ def test_result_bad_request(httpx_mock: HTTPXMock) -> None:
 
     with pytest.raises(httpx.HTTPError):
         backend.result(str(uuid.uuid4()))
+
+
+def test_resource_fixture_detect_invalid_circuits(
+    offline_simulator_no_noise: MockSimulator,
+) -> None:
+    """Pass a circuit that cannot be converted to the AQT API to the mock simulator.
+    This must fail.
+    """
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.cnot(0, 1)
+    qc.measure_all()
+
+    with pytest.raises(ValueError, match="^Circuit cannot be converted"):
+        offline_simulator_no_noise.run(qc)

--- a/test/test_transpilation.py
+++ b/test/test_transpilation.py
@@ -12,7 +12,7 @@
 
 
 from math import pi
-from typing import Final, Union
+from typing import Union
 
 import pytest
 from hypothesis import assume, given
@@ -191,19 +191,6 @@ def test_rxx_wrap_angle_case2_negative() -> None:
 
     assert_circuits_equal(result.decompose(), expected)
     assert_circuits_equivalent(result.decompose(), expected)
-
-
-RXX_ANGLES: Final = [
-    pi / 4,
-    pi / 2,
-    -pi / 2,
-    3 * pi / 4,
-    -3 * pi / 4,
-    15 * pi / 8,
-    -15 * pi / 8,
-    33 * pi / 16,
-    -33 * pi / 16,
-]
 
 
 @given(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch adds a specialized version of the Qiskit [`Sampler`](https://qiskit.org/documentation/apidoc/primitives.html#overview-of-sampler) primitive that enables the use of `Sampler`-based algorithms that have parametric circuits.

Depends on #57. The branch will be rebased after #57 is merged.

### Details and comments

- usage of the `AQTSampler` is mandatory with AQT resources because the custom transpilation passes need to work on parameter-bound circuits.
- `AQTSampler` implementation works around that limitation by delaying the application of the custom transpilation passes to after the parameters are bound to the circuit. This way, the partially transpiled circuits can still be cached by the underlying `BackendSampler` implementation.
- the `offline_simulator_no_noise` fixture is reworked to use a new `MockSimulator` class that encapsulates the specialized-mock post-processing rather than relying on `unittest.mock`. It is now arguable whether `offline_simulator_no_noise` should still be a fixture. We could clean this up at a later point if relevant.