### PR TITLE
Support server-side multi-circuits jobs API

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install main dependencies
         run: |
           poetry run pip install coverage[toml]
-          poetry install --only main --extras examples
+          poetry install --only main --all-extras
       - name: Run examples
         run: |
           poetry run examples/run_all.sh -c

--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install main dependencies
         run: |
           poetry run pip install coverage[toml]
-          poetry install --only main --all-extras
+          poetry install --only main --extras examples
       - name: Run examples
         run: |
           poetry run examples/run_all.sh -c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Always raise `TranspilerError` on errors in the custom transpilation passes #57
 * Add `AQTSampler`, a specialized implementation of the `Sampler` primitive #60
 * Auto-generate and use Pydantic models for the API requests payloads #62
+* Use server-side multi-circuits jobs API #63
+* Add job completion progress bar #63
 
 ## qiskit-aqt-provider v0.12.0
 

--- a/api/aqt_public.yml
+++ b/api/aqt_public.yml
@@ -188,22 +188,23 @@ components:
         job_type: quantum_circuit
         label: Example computation
         payload:
-          number_of_qubits: 3
-          quantum_circuit:
-          - operation: RZ
-            phi: 0.5
-            qubit: 0
-          - operation: R
-            phi: 0.25
-            qubit: 1
-            theta: 0.5
-          - operation: RXX
-            qubits:
-            - 0
-            - 1
-            theta: 0.5
-          - operation: MEASURE
-          repetitions: 5
+          circuits:
+          - number_of_qubits: 2
+            quantum_circuit:
+            - operation: RZ
+              phi: 0.5
+              qubit: 0
+            - operation: R
+              phi: 0.25
+              qubit: 1
+              theta: 0.5
+            - operation: RXX
+              qubits:
+              - 0
+              - 1
+              theta: 0.5
+            - operation: MEASURE
+            repetitions: 5
       properties:
         job_type:
           default: quantum_circuit
@@ -215,7 +216,7 @@ components:
           title: Label
           type: string
         payload:
-          $ref: '#/components/schemas/QuantumCircuit'
+          $ref: '#/components/schemas/QuantumCircuits'
       required:
       - payload
       title: JobSubmission
@@ -330,6 +331,37 @@ components:
       - number_of_qubits
       title: QuantumCircuit
       type: object
+    QuantumCircuits:
+      description: A collection of quantum circuits representing a single job.
+      example:
+        circuits:
+        - number_of_qubits: 2
+          quantum_circuit:
+          - operation: RZ
+            phi: 0.5
+            qubit: 0
+          - operation: R
+            phi: 0.25
+            qubit: 1
+            theta: 0.5
+          - operation: RXX
+            qubits:
+            - 0
+            - 1
+            theta: 0.5
+          - operation: MEASURE
+          repetitions: 5
+      properties:
+        circuits:
+          items:
+            $ref: '#/components/schemas/QuantumCircuit'
+          minItems: 1
+          title: Circuits
+          type: array
+      required:
+      - circuits
+      title: QuantumCircuits
+      type: object
     RRCancelled:
       example:
         status: cancelled
@@ -364,32 +396,35 @@ components:
       description: Contains the measurement data of a finished circuit.
       example:
         result:
-        - - 0
-          - 1
-          - 1
-        - - 1
-          - 1
-          - 1
-        - - 0
-          - 0
-          - 0
-        - - 1
-          - 1
-          - 0
-        - - 1
-          - 1
-          - 0
+          0:
+          - - 0
+            - 1
+            - 1
+          - - 1
+            - 1
+            - 1
+          - - 0
+            - 0
+            - 0
+          - - 1
+            - 1
+            - 0
+          - - 1
+            - 1
+            - 0
         status: finished
       properties:
         result:
-          items:
+          additionalProperties:
             items:
-              maximum: 1.0
-              minimum: 0.0
-              type: integer
+              items:
+                maximum: 1.0
+                minimum: 0.0
+                type: integer
+              type: array
             type: array
           title: Result
-          type: array
+          type: object
         status:
           default: finished
           enum:
@@ -402,14 +437,21 @@ components:
       type: object
     RROngoing:
       example:
+        finished_count: 0
         status: ongoing
       properties:
+        finished_count:
+          minimum: 0.0
+          title: Finished Count
+          type: integer
         status:
           default: ongoing
           enum:
           - ongoing
           title: Status
           type: string
+      required:
+      - finished_count
       title: RROngoing
       type: object
     RRQueued:
@@ -508,21 +550,17 @@ components:
               workspace_id: ''
             response:
               result:
-              - - 1
-                - 0
-                - 0
-              - - 1
-                - 1
-                - 0
-              - - 0
-                - 0
-                - 0
-              - - 1
-                - 1
-                - 0
-              - - 1
-                - 1
-                - 0
+                0:
+                - - 1
+                  - 0
+                - - 1
+                  - 1
+                - - 0
+                  - 0
+                - - 1
+                  - 1
+                - - 1
+                  - 1
               status: finished
         ongoing:
           description: Job that is currently being processed by the Quantum computer
@@ -535,6 +573,7 @@ components:
               resource_id: ''
               workspace_id: ''
             response:
+              finished_count: 0
               status: ongoing
         queued:
           description: Job waiting in the queue to be picked up by the Quantum computer
@@ -547,7 +586,7 @@ components:
               resource_id: ''
               workspace_id: ''
             response:
-              status: cancelled
+              status: queued
         unknown:
           description: The supplied job id could not be found
           summary: Unknown Job
@@ -616,9 +655,14 @@ components:
       - resources
       title: Workspace
       type: object
+  securitySchemes:
+    Bearer Token:
+      description: To authenticate for the API provide a valid token (without 'Bearer')
+      scheme: bearer
+      type: http
 info:
   title: AQT Public API
-  version: 0.2.0
+  version: 0.3.0
 openapi: 3.0.2
 paths:
   /result/{job_id}:
@@ -632,15 +676,6 @@ paths:
         schema:
           format: uuid
           title: Job Id
-          type: string
-      - description: AQT cloud access token
-        in: header
-        name: authorization
-        required: false
-        schema:
-          default: token
-          description: AQT cloud access token
-          title: Authorization
           type: string
       responses:
         '200':
@@ -687,21 +722,17 @@ paths:
                       workspace_id: ''
                     response:
                       result:
-                      - - 1
-                        - 0
-                        - 0
-                      - - 1
-                        - 1
-                        - 0
-                      - - 0
-                        - 0
-                        - 0
-                      - - 1
-                        - 1
-                        - 0
-                      - - 1
-                        - 1
-                        - 0
+                        0:
+                        - - 1
+                          - 0
+                        - - 1
+                          - 1
+                        - - 0
+                          - 0
+                        - - 1
+                          - 1
+                        - - 1
+                          - 1
                       status: finished
                 ongoing:
                   description: Job that is currently being processed by the Quantum
@@ -715,6 +746,7 @@ paths:
                       resource_id: ''
                       workspace_id: ''
                     response:
+                      finished_count: 0
                       status: ongoing
                 queued:
                   description: Job waiting in the queue to be picked up by the Quantum
@@ -728,7 +760,7 @@ paths:
                       resource_id: ''
                       workspace_id: ''
                     response:
-                      status: cancelled
+                      status: queued
                 unknown:
                   description: The supplied job id could not be found
                   summary: Unknown Job
@@ -738,12 +770,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResultResponse'
           description: Success
+        '401':
+          description: Unauthorized
         '422':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - Bearer Token: []
       summary: Request Result
   /submit/{workspace}/{resource}:
     post:
@@ -762,15 +798,6 @@ paths:
         schema:
           title: Resource
           type: string
-      - description: AQT cloud access token
-        in: header
-        name: authorization
-        required: false
-        schema:
-          default: token
-          description: AQT cloud access token
-          title: Authorization
-          type: string
       requestBody:
         content:
           application/json:
@@ -784,27 +811,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobResponse_RRQueued_'
           description: Successful Response
+        '401':
+          description: Unauthorized
         '422':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      security:
+      - Bearer Token: []
       summary: Submit Job
   /workspaces:
     get:
       description: List of available workspaces and devices
       operationId: workspaces_workspaces_get
-      parameters:
-      - description: AQT cloud access token
-        in: header
-        name: authorization
-        required: false
-        schema:
-          default: token
-          description: AQT cloud access token
-          title: Authorization
-          type: string
       responses:
         '200':
           content:
@@ -815,10 +836,8 @@ paths:
                 title: Response Workspaces Workspaces Get
                 type: array
           description: Successful Response
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-          description: Validation Error
+        '401':
+          description: Unauthorized
+      security:
+      - Bearer Token: []
       summary: Workspaces

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -94,7 +94,7 @@ automatically:
 
 .. jupyter-execute::
 
-    job = execute(qc, backend)
+    job = execute(qc, backend, with_progress_bar=False)
 
 
 To retrieve wait for a result to be available and retrieve it, use

--- a/examples/example.py
+++ b/examples/example.py
@@ -21,7 +21,7 @@ from qiskit_aqt_provider.aqt_provider import AQTProvider
 if __name__ == "__main__":
     # If no `access_token` is passed to the constructor it is read from
     # the AQT_TOKEN environment variable
-    provider = AQTProvider("")
+    provider = AQTProvider("token")
 
     # The workspaces method returns a list of available workspaces and resources
     print(provider.workspaces())
@@ -42,4 +42,4 @@ if __name__ == "__main__":
     if result.success:
         print(result.get_counts())
     else:  # pragma: no cover
-        print(result.to_dict()["errors"])
+        print(result.to_dict()["error"])

--- a/examples/grover-3-sat.py
+++ b/examples/grover-3-sat.py
@@ -23,9 +23,9 @@ from typing import Final, Set, Tuple
 
 from qiskit.algorithms import AmplificationProblem, Grover
 from qiskit.circuit.library.phase_oracle import PhaseOracle
-from qiskit.primitives import BackendSampler
 
 from qiskit_aqt_provider import AQTProvider
+from qiskit_aqt_provider.primitives import AQTSampler
 
 
 class ThreeSatProblem:
@@ -80,8 +80,8 @@ if __name__ == "__main__":
     )
 
     # Select the sampling engine
-    backend = AQTProvider("").get_resource("default", "offline_simulator_no_noise")
-    sampler = BackendSampler(backend)
+    backend = AQTProvider("token").get_resource("default", "offline_simulator_no_noise")
+    sampler = AQTSampler(backend)
 
     # Map the problem to a Grover search
     problem = AmplificationProblem(sat_problem.oracle, is_good_state=sat_problem.is_solution)

--- a/poetry.lock
+++ b/poetry.lock
@@ -447,7 +447,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
@@ -3854,6 +3854,27 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.65.0"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.65.0-py3-none-any.whl", hash = "sha256:c4f53a17fe37e132815abceec022631be8ffe1b9381c2e6e30aa70edc99e9671"},
+    {file = "tqdm-4.65.0.tar.gz", hash = "sha256:1871fb68a86b8fb3b59ca4cdd3dcccbc7e6d613eeed31f4c332531977b89beb5"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "traitlets"
 version = "5.9.0"
 description = "Traitlets Python configuration system"
@@ -3995,6 +4016,18 @@ python-versions = "*"
 files = [
     {file = "types-tabulate-0.9.0.2.tar.gz", hash = "sha256:1dd4322a3a146e9073169c74278b8f14a58eb9905ca9db0d2588df408f27cac9"},
     {file = "types_tabulate-0.9.0.2-py3-none-any.whl", hash = "sha256:a2e41cc41b6b46bfaec78f8fd8e03058fda7a31af6f203a4b235f5482f571f6f"},
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.65.0.1"
+description = "Typing stubs for tqdm"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-tqdm-4.65.0.1.tar.gz", hash = "sha256:972dd871b6b2b8ff32f1f0f6fdfdf5a4ba2b0b848453689391bec8bd858fb1c4"},
+    {file = "types_tqdm-4.65.0.1-py3-none-any.whl", hash = "sha256:4894fe2b1581374ce9bca3f23d53729e4409d69b352e3d5db5829fa19482962c"},
 ]
 
 [[package]]
@@ -4243,8 +4276,9 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [extras]
 examples = ["tweedledum"]
+progress-bar = ["tqdm"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9a59ba01aaf19748951f42e51ac2e22101f05b86a5fb909f626b3590579fa568"
+content-hash = "81849af6d1827bbefdb5b2146dab98f91ecdefaf87c29bf922e9537300169313"

--- a/poetry.lock
+++ b/poetry.lock
@@ -773,22 +773,6 @@ files = [
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
-name = "dirty-equals"
-version = "0.5.0"
-description = "Doing dirty (but extremely useful) things with equals."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "dirty_equals-0.5.0-py3-none-any.whl", hash = "sha256:23f4108be991e2661c0c81ae6deedc0bd25b3cc0ecdd7482dbad7b2bc795308f"},
-    {file = "dirty_equals-0.5.0.tar.gz", hash = "sha256:f107137476d784b7f86757a3e1291fe11e8166d4720df9c02a3ee5dfa595e1fe"},
-]
-
-[package.dependencies]
-pytz = ">=2021.3"
-typing-extensions = ">=4.0.1"
-
-[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -4263,4 +4247,4 @@ examples = ["tweedledum"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "be0c9c75f37a91995e12fffcff428ed661262c13bcf70fc8abadb06d39d03be6"
+content-hash = "9a59ba01aaf19748951f42e51ac2e22101f05b86a5fb909f626b3590579fa568"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3858,7 +3858,7 @@ name = "tqdm"
 version = "4.65.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "tqdm-4.65.0-py3-none-any.whl", hash = "sha256:c4f53a17fe37e132815abceec022631be8ffe1b9381c2e6e30aa70edc99e9671"},
@@ -4276,9 +4276,8 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [extras]
 examples = ["tweedledum"]
-progress-bar = ["tqdm"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "81849af6d1827bbefdb5b2146dab98f91ecdefaf87c29bf922e9537300169313"
+content-hash = "14b640c8afb1df2d77b5cb4989b3a9b644884d89a6cf93a199a7b031c589f7b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ python-dotenv = ">=1"
 qiskit-aer = ">=0.11"
 qiskit-terra = ">=0.23.3"
 tabulate = ">=0.9.0"
+tqdm = { version = ">=4", optional = true }
 tweedledum = { version = ">=1", optional = true }
 typing-extensions = ">=4.0.0"
 
@@ -79,11 +80,15 @@ typer = "^0.7.0"
 types-requests = "^2.28.11"
 types-setuptools = "^65.7.0"
 types-tabulate = "^0.9.0.1"
+types-tqdm = "^4.65.0.1"
 
 
 [tool.poetry.extras]
 examples = [
     "tweedledum"
+]
+progress-bar = [
+    "tqdm"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ typing-extensions = ">=4.0.0"
 black = "^23.3.0"
 coverage = "^7.2.1"
 datamodel-code-generator = { git = "https://github.com/airwoodix/datamodel-code-generator", branch = "annotated-backport" }
-dirty-equals = "^0.5.0"
 hypothesis = "^6.70.0"
 ipykernel = "^6.22.0"
 jupyter-sphinx = "^0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ python-dotenv = ">=1"
 qiskit-aer = ">=0.11"
 qiskit-terra = ">=0.23.3"
 tabulate = ">=0.9.0"
-tqdm = { version = ">=4", optional = true }
+tqdm = ">=4"
 tweedledum = { version = ">=1", optional = true }
 typing-extensions = ">=4.0.0"
 
@@ -82,13 +82,9 @@ types-setuptools = "^65.7.0"
 types-tabulate = "^0.9.0.1"
 types-tqdm = "^4.65.0.1"
 
-
 [tool.poetry.extras]
 examples = [
     "tweedledum"
-]
-progress-bar = [
-    "tqdm"
 ]
 
 [build-system]

--- a/qiskit_aqt_provider/api_models_generated.py
+++ b/qiskit_aqt_provider/api_models_generated.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Extra, Field
@@ -148,7 +148,7 @@ class RRFinished(BaseModel):
     class Config:
         allow_mutation = False
 
-    result: Annotated[List[List[ResultItem]], Field(title="Result")]
+    result: Annotated[Dict[str, List[List[ResultItem]]], Field(title="Result")]
     status: Annotated[Literal["finished"], Field(title="Status")] = "finished"
 
 
@@ -156,6 +156,7 @@ class RROngoing(BaseModel):
     class Config:
         allow_mutation = False
 
+    finished_count: Annotated[int, Field(ge=0, title="Finished Count")]
     status: Annotated[Literal["ongoing"], Field(title="Status")] = "ongoing"
 
 
@@ -312,6 +313,17 @@ class QuantumCircuit(BaseModel):
     repetitions: Annotated[int, Field(gt=0, title="Repetitions")]
 
 
+class QuantumCircuits(BaseModel):
+    """
+    A collection of quantum circuits representing a single job.
+    """
+
+    class Config:
+        allow_mutation = False
+
+    circuits: Annotated[List[QuantumCircuit], Field(min_items=1, title="Circuits")]
+
+
 class ResultResponse(BaseModel):
     class Config:
         allow_mutation = False
@@ -375,7 +387,7 @@ class ResultResponse(BaseModel):
                             "workspace_id": "",
                         },
                         "response": {
-                            "result": [[1, 0, 0], [1, 1, 0], [0, 0, 0], [1, 1, 0], [1, 1, 0]],
+                            "result": {0: [[1, 0], [1, 1], [0, 0], [1, 1], [1, 1]]},
                             "status": "finished",
                         },
                     },
@@ -391,7 +403,7 @@ class ResultResponse(BaseModel):
                             "resource_id": "",
                             "workspace_id": "",
                         },
-                        "response": {"status": "ongoing"},
+                        "response": {"finished_count": 0, "status": "ongoing"},
                     },
                 },
                 "queued": {
@@ -407,7 +419,7 @@ class ResultResponse(BaseModel):
                             "resource_id": "",
                             "workspace_id": "",
                         },
-                        "response": {"status": "cancelled"},
+                        "response": {"status": "queued"},
                     },
                 },
                 "unknown": {
@@ -434,4 +446,4 @@ class JobSubmission(BaseModel):
 
     job_type: Annotated[Literal["quantum_circuit"], Field(title="Job Type")] = "quantum_circuit"
     label: Annotated[Optional[str], Field(title="Label")] = None
-    payload: QuantumCircuit
+    payload: QuantumCircuits

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -10,14 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import threading
 import uuid
 from collections import Counter, defaultdict, namedtuple
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     DefaultDict,
     Dict,
@@ -33,7 +30,7 @@ from qiskit.providers import JobV1
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.result.result import Result
 from qiskit.utils.lazy_tester import contextlib
-from typing_extensions import assert_never
+from typing_extensions import TypeAlias, assert_never
 
 from qiskit_aqt_provider import api_models_generated
 
@@ -49,7 +46,7 @@ class JobFinished:
     """The job finished successfully."""
 
     status: ClassVar = JobStatus.DONE
-    samples: List[List[int]]
+    results: Dict[int, List[List[int]]]
 
 
 @dataclass
@@ -66,16 +63,37 @@ class JobQueued:
     status: ClassVar = JobStatus.QUEUED
 
 
+@dataclass
 class JobOngoing:
     """The job is running."""
 
     status: ClassVar = JobStatus.RUNNING
+    finished_count: int
 
 
 class JobCancelled:
     """The job was cancelled."""
 
     status = ClassVar = JobStatus.CANCELLED
+
+
+JobStatusPayload: TypeAlias = Union[JobQueued, JobOngoing, JobFinished, JobFailed, JobCancelled]
+
+
+@dataclass(frozen=True)
+class Progress:
+    """Progress information of a job."""
+
+    finished_count: int
+    """Number of completed circuits."""
+
+    total_count: int
+    """Total number of circuits in the job."""
+
+    @property
+    def percentage(self) -> float:
+        """Progress as percentage."""
+        return self.finished_count / self.total_count * 100.0
 
 
 class AQTJob(JobV1):
@@ -90,55 +108,75 @@ class AQTJob(JobV1):
         """Initialize a job instance.
 
         Parameters:
-            backend (BaseBackend): Backend that job was executed on.
-            circuits (List[QuantumCircuit]): List of circuits to execute.
-            shots (int): Number of repetitions per circuit.
+            backend: backend to run the job on
+            circuits: list of circuits to execute
+            shots: number of repetitions per circuit.
         """
-        super().__init__(backend, str(uuid.uuid4()))
+        super().__init__(backend, "")
 
-        self.shots = shots
         self.circuits = circuits
-
-        self._jobs: Dict[
-            uuid.UUID, Union[JobFinished, JobFailed, JobQueued, JobOngoing, JobCancelled]
-        ] = {}
-        self._jobs_lock = threading.Lock()
+        self.shots = shots
+        self.status_payload: JobStatusPayload = JobQueued()
 
     def submit(self) -> None:
-        """Submits a job for execution."""
-        # do not parallelize to guarantee that the order is preserved in the _jobs dict
-        for circuit in self.circuits:
-            self._submit_single(circuit, self.shots)
+        job_id = self._backend.submit(self.circuits, self.shots)
+        self._job_id = str(job_id)
 
     def status(self) -> JobStatus:
         """Query the job's status.
 
-        The job status is aggregated from the status of the individual circuits running
-        on the AQT resource.
-
         Returns:
             JobStatus: aggregated job status for all the circuits in this job.
-
-        Raises:
-            RuntimeError: an unexpected error occurred while retrieving a circuit status.
         """
-        # update the local job cache
-        with ThreadPoolExecutor(thread_name_prefix="status_worker_") as pool:
-            futures = [pool.submit(self._status_single, job_id) for job_id in self._jobs]
+        payload = self._backend.result(uuid.UUID(self.job_id()))
 
-            for fut in as_completed(futures, timeout=10.0):
-                if (exc := fut.exception()) is not None:
-                    raise RuntimeError("Unexpected error while retrieving job status.") from exc
+        if isinstance(payload, api_models_generated.JobResponseRRQueued):
+            self.status_payload = JobQueued()
+        elif isinstance(payload, api_models_generated.JobResponseRROngoing):
+            self.status_payload = JobOngoing(finished_count=payload.response.finished_count)
+        elif isinstance(payload, api_models_generated.JobResponseRRFinished):
+            self.status_payload = JobFinished(
+                results={
+                    int(circuit_index): [[sample.__root__ for sample in shot] for shot in shots]
+                    for circuit_index, shots in payload.response.result.items()
+                }
+            )
+        elif isinstance(payload, api_models_generated.JobResponseRRError):
+            self.status_payload = JobFailed(error=payload.response.message)
+        elif isinstance(payload, api_models_generated.JobResponseRRCancelled):
+            self.status_payload = JobCancelled()
+        else:  # pragma: no cover
+            assert_never(payload)
 
-        return self._aggregate_status()
+        return self.status_payload.status
+
+    def progress(self) -> Progress:
+        """Progress information for this job."""
+        num_circuits = len(self.circuits)
+
+        if isinstance(self.status_payload, JobQueued):
+            return Progress(finished_count=0, total_count=num_circuits)
+
+        if isinstance(self.status_payload, JobOngoing):
+            return Progress(
+                finished_count=self.status_payload.finished_count, total_count=num_circuits
+            )
+
+        # if the circuit is finished, failed, or cancelled, it is completed
+        return Progress(finished_count=num_circuits, total_count=num_circuits)
+
+    @property
+    def error_message(self) -> Optional[str]:
+        """Error message for this job (if any)."""
+        if isinstance(self.status_payload, JobFailed):
+            return self.status_payload.error
+
+        return None
 
     def result(self) -> Result:
         """Block until all circuits have been evaluated and return the combined result.
 
         Success or error is signalled by the `success` field in the returned Result instance.
-
-        In case of error, use `AQTJobNew.failed_jobs` to access the error messages of the
-        failed circuit evaluations.
 
         Returns:
             The combined result of all circuit evaluations.
@@ -149,36 +187,32 @@ class AQTJob(JobV1):
             wait=self._backend.options.query_period_seconds,
         )
 
-        agg_status = self._aggregate_status()
-
         results = []
 
-        # jobs order is submission order
-        for circuit, result in zip(self.circuits, self._jobs.values()):
-            data: Dict[str, Any] = {}
-
-            if isinstance(result, JobFinished):
+        if isinstance(self.status_payload, JobFinished):
+            for circuit_index, circuit in enumerate(self.circuits):
+                samples = self.status_payload.results[circuit_index]
                 meas_map = _build_memory_mapping(circuit)
-                data["counts"] = _format_counts(result.samples, meas_map)
-                data["memory"] = [
-                    "".join(str(x) for x in reversed(shots)) for shots in result.samples
-                ]
-
-            results.append(
-                {
-                    "shots": self.shots,
-                    "success": result.status is JobStatus.DONE,
-                    "status": result.status.value,
-                    "data": data,
-                    "header": {
-                        "memory_slots": circuit.num_clbits,
-                        "creg_sizes": [[reg.name, reg.size] for reg in circuit.cregs],
-                        "qreg_sizes": [[reg.name, reg.size] for reg in circuit.qregs],
-                        "name": circuit.name,
-                        "metadata": circuit.metadata or {},
-                    },
+                data = {
+                    "counts": _format_counts(samples, meas_map),
+                    "memory": ["".join(str(x) for x in reversed(states)) for states in samples],
                 }
-            )
+
+                results.append(
+                    {
+                        "shots": self.shots,
+                        "success": True,
+                        "status": JobStatus.DONE,
+                        "data": data,
+                        "header": {
+                            "memory_slots": circuit.num_clbits,
+                            "creg_sizes": [[reg.name, reg.size] for reg in circuit.cregs],
+                            "qreg_sizes": [[reg.name, reg.size] for reg in circuit.qregs],
+                            "name": circuit.name,
+                            "metadata": circuit.metadata or {},
+                        },
+                    }
+                )
 
         return Result.from_dict(
             {
@@ -186,89 +220,12 @@ class AQTJob(JobV1):
                 "backend_version": self._backend.version,
                 "qobj_id": id(self.circuits),
                 "job_id": self.job_id(),
-                "success": agg_status is JobStatus.DONE,
+                "success": self.status_payload.status is JobStatus.DONE,
                 "results": results,
-                # Pass individual circuit errors as metadata
-                "errors": self.failed_jobs,
+                # Pass error message as metadata
+                "error": self.error_message,
             }
         )
-
-    @property
-    def job_ids(self) -> Set[uuid.UUID]:
-        """The AQT API identifiers of all the circuits evaluated in this Qiskit job."""
-        return set(self._jobs)
-
-    @property
-    def failed_jobs(self) -> Dict[uuid.UUID, str]:
-        """Map of failed job ids to error reports from the API."""
-        with self._jobs_lock:
-            return {
-                job_id: payload.error
-                for job_id, payload in self._jobs.items()
-                if isinstance(payload, JobFailed)
-            }
-
-    def _submit_single(self, circuit: QuantumCircuit, shots: int) -> None:
-        """Submit a single quantum circuit for execution on the backend.
-
-        Parameters:
-            circuit (QuantumCircuit): The quantum circuit to execute
-            shots (int): Number of repetitions
-
-        Returns:
-            The AQT job identifier.
-        """
-        job_id = self._backend.submit(circuit, shots)
-        with self._jobs_lock:
-            self._jobs[job_id] = JobQueued()
-
-    def _status_single(self, job_id: uuid.UUID) -> None:
-        """Query the status of a single circuit execution.
-
-        This method updates the internal life-cycle tracker.
-        """
-        payload = self._backend.result(job_id)
-
-        with self._jobs_lock:
-            # TODO: why don't user-defined TypeGuards narrow the type properly?
-            if isinstance(payload, api_models_generated.JobResponseRRQueued):
-                self._jobs[job_id] = JobQueued()
-            elif isinstance(payload, api_models_generated.JobResponseRROngoing):
-                self._jobs[job_id] = JobOngoing()
-            elif isinstance(payload, api_models_generated.JobResponseRRFinished):
-                self._jobs[job_id] = JobFinished(
-                    samples=[[state.__root__ for state in shot] for shot in payload.response.result]
-                )
-            elif isinstance(payload, api_models_generated.JobResponseRRError):
-                self._jobs[job_id] = JobFailed(error=payload.response.message)
-            elif isinstance(payload, api_models_generated.JobResponseRRCancelled):
-                self._jobs[job_id] = JobCancelled()
-            else:  # pragma: no cover
-                assert_never(payload)
-
-    def _aggregate_status(self) -> JobStatus:
-        """Aggregate the Qiskit job status from the status of the individual circuit evaluations."""
-        # aggregate job status from individual circuits
-        with self._jobs_lock:
-            statuses = [payload.status for payload in self._jobs.values()]
-
-        if any(s is JobStatus.ERROR for s in statuses):
-            return JobStatus.ERROR
-
-        if any(s is JobStatus.CANCELLED for s in statuses):
-            return JobStatus.CANCELLED
-
-        if any(s is JobStatus.RUNNING for s in statuses):
-            return JobStatus.RUNNING
-
-        if all(s is JobStatus.QUEUED for s in statuses):
-            return JobStatus.QUEUED
-
-        if all(s is JobStatus.DONE for s in statuses):
-            return JobStatus.DONE
-
-        # TODO: check for completeness
-        return JobStatus.QUEUED
 
 
 def _build_memory_mapping(circuit: QuantumCircuit) -> Dict[int, Set[int]]:

--- a/qiskit_aqt_provider/aqt_job.py
+++ b/qiskit_aqt_provider/aqt_job.py
@@ -31,6 +31,7 @@ from qiskit.providers import JobV1
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.result.result import Result
 from qiskit.utils.lazy_tester import contextlib
+from tqdm import tqdm
 from typing_extensions import Self, TypeAlias, assert_never
 
 from qiskit_aqt_provider import api_models_generated
@@ -211,8 +212,6 @@ class AQTJob(JobV1):
             The combined result of all circuit evaluations.
         """
         if self.with_progress_bar:
-            from tqdm import tqdm
-
             context: Union[tqdm[NoReturn], _MockProgressBar] = tqdm(total=len(self.circuits))
         else:
             context = _MockProgressBar(total=len(self.circuits))

--- a/qiskit_aqt_provider/aqt_resource.py
+++ b/qiskit_aqt_provider/aqt_resource.py
@@ -156,6 +156,7 @@ class AQTResource(Backend):
         self.options.set_validator("shots", (1, 200))
         self.options.set_validator("query_timeout_seconds", OptionalFloat)
         self.options.set_validator("query_period_seconds", Float)
+        self.options.set_validator("with_progress_bar", bool)
 
     def submit(self, circuits: List[QuantumCircuit], shots: int) -> UUID:
         """Submit a quantum circuits job to the AQT backend.
@@ -228,6 +229,7 @@ class AQTResource(Backend):
             shots=100,  # number of repetitions per circuit
             query_timeout_seconds=None,  # timeout for job status queries
             query_period_seconds=5,  # interval between job status queries
+            with_progress_bar=True,  # show a progress bar when waiting for job results
         )
 
     def get_scheduling_stage_plugin(self) -> str:
@@ -250,8 +252,9 @@ class AQTResource(Backend):
                 )
 
         shots = options.get("shots", self.options.shots)
+        with_progress_bar = options.get("with_progress_bar", self.options.with_progress_bar)
 
-        job = AQTJob(self, circuits, shots)
+        job = AQTJob(self, circuits, shots, with_progress_bar=with_progress_bar)
         job.submit()
         return job
 

--- a/qiskit_aqt_provider/aqt_resource.py
+++ b/qiskit_aqt_provider/aqt_resource.py
@@ -229,7 +229,7 @@ class AQTResource(Backend):
         return Options(
             shots=100,  # number of repetitions per circuit
             query_timeout_seconds=None,  # timeout for job status queries
-            query_period_seconds=5,  # interval between job status queries
+            query_period_seconds=1,  # interval between job status queries
             with_progress_bar=True,  # show a progress bar when waiting for job results
         )
 

--- a/qiskit_aqt_provider/aqt_resource.py
+++ b/qiskit_aqt_provider/aqt_resource.py
@@ -12,7 +12,8 @@
 
 import abc
 import warnings
-from typing import Any, Dict, List, Type, TypeVar, Union
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 from uuid import UUID
 
 import httpx
@@ -29,7 +30,7 @@ from typing_extensions import TypedDict
 
 from qiskit_aqt_provider import api_models
 from qiskit_aqt_provider.aqt_job import AQTJob
-from qiskit_aqt_provider.circuit_to_aqt import circuit_to_aqt_job
+from qiskit_aqt_provider.circuit_to_aqt import circuits_to_aqt_job
 from qiskit_aqt_provider.constants import REQUESTS_TIMEOUT
 
 
@@ -156,22 +157,23 @@ class AQTResource(Backend):
         self.options.set_validator("query_timeout_seconds", OptionalFloat)
         self.options.set_validator("query_period_seconds", Float)
 
-    def submit(self, circuit: QuantumCircuit, shots: int) -> UUID:
-        """Submit a circuit.
+    def submit(self, circuits: List[QuantumCircuit], shots: int) -> UUID:
+        """Submit a quantum circuits job to the AQT backend.
 
-        Parameters:
-            circuit: quantum circuit to execute on the backend
-            shots: number repetitions of the circuit
+        Args:
+            circuits: circuits to execute
+            shots: number of repetitions per circuit.
 
         Returns:
-            The unique identifier for the submitted job.
+            The unique identifier of the submitted job.
         """
-        payload = circuit_to_aqt_job(circuit, shots=shots)
+        payload = circuits_to_aqt_job(circuits, shots)
 
         url = f"{self.url}/submit/{self._workspace}/{self._resource['id']}"
-        req = httpx.post(url, json=payload.json(), headers=self.headers, timeout=REQUESTS_TIMEOUT)
+
+        req = httpx.post(url, json=payload.dict(), headers=self.headers, timeout=REQUESTS_TIMEOUT)
         req.raise_for_status()
-        return api_models.Response.parse_raw(req.json()).job.job_id
+        return api_models.Response.parse_obj(req.json()).job.job_id
 
     def result(self, job_id: UUID) -> api_models.JobResponse:
         """Query the result for a specific job.
@@ -185,7 +187,7 @@ class AQTResource(Backend):
         url = f"{self.url}/result/{job_id}"
         req = httpx.get(url, headers=self.headers, timeout=REQUESTS_TIMEOUT)
         req.raise_for_status()
-        return api_models.Response.parse_raw(req.json())
+        return api_models.Response.parse_obj(req.json())
 
     def configuration(self) -> BackendConfiguration:
         warnings.warn(
@@ -234,9 +236,9 @@ class AQTResource(Backend):
     def get_translation_stage_plugin(self) -> str:
         return "aqt"
 
-    def run(self, run_input: Union[QuantumCircuit, List[QuantumCircuit]], **options: Any) -> AQTJob:
-        if not isinstance(run_input, list):
-            run_input = [run_input]
+    def run(self, circuits: Union[QuantumCircuit, List[QuantumCircuit]], **options: Any) -> AQTJob:
+        if not isinstance(circuits, list):
+            circuits = [circuits]
 
         unknown_options = set(options) - set(self.options.__dict__ or {})
         if unknown_options:
@@ -249,7 +251,7 @@ class AQTResource(Backend):
 
         shots = options.get("shots", self.options.shots)
 
-        job = AQTJob(self, circuits=run_input, shots=shots)
+        job = AQTJob(self, circuits, shots)
         job.submit()
         return job
 
@@ -274,6 +276,9 @@ def qubit_states_from_int(state: int, num_qubits: int) -> List[int]:
         >>> qubit_states_from_int(0b11, 3)
         [1, 1, 0]
 
+        >>> qubit_states_from_int(0b01, 3)
+        [1, 0, 0]
+
         >>> qubit_states_from_int(123, 7)
         [1, 1, 0, 1, 1, 1, 1]
 
@@ -287,6 +292,17 @@ def qubit_states_from_int(state: int, num_qubits: int) -> List[int]:
     return [(state >> qubit) & 1 for qubit in range(num_qubits)]
 
 
+@dataclass(frozen=True)
+class SimulatorJob:
+    job: AerJob
+    circuits: List[QuantumCircuit]
+    shots: int
+
+    @property
+    def job_id(self) -> UUID:
+        return UUID(hex=self.job.job_id())
+
+
 class OfflineSimulatorResource(AQTResource):
     """AQT-compatible offline simulator resource that uses the Qiskit-Aer backend."""
 
@@ -297,28 +313,65 @@ class OfflineSimulatorResource(AQTResource):
         # TODO: also support a noisy simulator
         super().__init__(provider, workspace, resource)
 
-        self.jobs: Dict[UUID, AerJob] = {}
+        self.job: Optional[SimulatorJob] = None
         self.simulator = AerSimulator(method="statevector")
 
-    def submit(self, circuit: QuantumCircuit, shots: int) -> UUID:
-        job = self.simulator.run(circuit, shots=shots)
-        job_id = UUID(hex=job.job_id())
-        self.jobs[job_id] = job
-        return job_id
+    def submit(self, circuits: List[QuantumCircuit], shots: int) -> UUID:
+        """Submit circuits for execution on the simulator.
+
+        Args:
+            circuits: circuits to execute
+            shots: number of repetitions per circuit.
+
+        Returns:
+            Unique identifier of the simulator job.
+        """
+        self.job = SimulatorJob(
+            job=self.simulator.run(circuits, shots=shots),
+            circuits=circuits,
+            shots=shots,
+        )
+        return self.job.job_id
 
     def result(self, job_id: UUID) -> api_models.JobResponse:
-        qiskit_result = self.jobs[job_id].result()
-        counts = qiskit_result.data()["counts"]
-        num_qubits = qiskit_result.results[0].header.n_qubits
-        samples = []
-        for hex_state, occurences in counts.items():
-            samples.extend(
-                [qubit_states_from_int(int(hex_state, 16), num_qubits) for _ in range(occurences)]
-            )
+        """Query results for a simulator job.
+
+        Args:
+            job_id: identifier of the job to retrieve results for.
+
+        Returns:
+            AQT API payload with the job results.
+
+        Raises:
+            UnknownJobError: the passed identifier doesn't correspond to a simulator job
+            on this resource.
+        """
+        if self.job is None or job_id != self.job.job_id:
+            raise api_models.UnknownJobError(str(job_id))
+
+        qiskit_result = self.job.job.result()
+
+        results: Dict[str, List[List[int]]] = {}
+        for circuit_index, circuit in enumerate(self.job.circuits):
+            samples: List[List[int]] = []
+
+            # Use data()["counts"] instead of get_counts() to access the raw counts
+            # instead of the classical memory-mapped ones.
+            counts: Dict[str, int] = qiskit_result.data(circuit_index)["counts"]
+
+            for hex_state, occurences in counts.items():
+                samples.extend(
+                    [
+                        qubit_states_from_int(int(hex_state, 16), circuit.num_qubits)
+                        for _ in range(occurences)
+                    ]
+                )
+
+            results[str(circuit_index)] = samples
 
         return api_models.Response.finished(
             job_id=job_id,
             workspace_id=self._workspace,
             resource_id=self._resource["id"],
-            samples=samples,
+            results=results,
         )

--- a/qiskit_aqt_provider/primitives/sampler.py
+++ b/qiskit_aqt_provider/primitives/sampler.py
@@ -62,10 +62,14 @@ class AQTSampler(BackendSampler):
             ]
         )
 
+        # if `with_progress_bar` is not explicitly set in the options, disable it
+        options_copy = (options or {}).copy()
+        options_copy.update(with_progress_bar=options_copy.get("with_progress_bar", False))
+
         super().__init__(
             mod_backend,
             bound_pass_manager=bound_pass_manager,
-            options=options,
+            options=options_copy,
             skip_transpilation=skip_transpilation,
         )
 

--- a/qiskit_aqt_provider/test/fixtures.py
+++ b/qiskit_aqt_provider/test/fixtures.py
@@ -23,9 +23,7 @@ from qiskit.circuit import QuantumCircuit
 
 from qiskit_aqt_provider.aqt_provider import AQTProvider
 from qiskit_aqt_provider.aqt_resource import ApiResource, OfflineSimulatorResource
-from qiskit_aqt_provider.circuit_to_aqt import (
-    _qiskit_to_aqt_circuit,
-)
+from qiskit_aqt_provider.circuit_to_aqt import _qiskit_to_aqt_circuit
 
 
 class MockSimulator(OfflineSimulatorResource):
@@ -59,7 +57,7 @@ class MockSimulator(OfflineSimulatorResource):
                 _ = _qiskit_to_aqt_circuit(circuit)
             except Exception as e:  # noqa: BLE001
                 raise ValueError(
-                    "Circuit cannot be converted to AQT JSON format:\n{circuit}"
+                    f"Circuit cannot be converted to AQT JSON format:\n{circuit}"
                 ) from e
 
         self.submit_call_args.append((circuits, shots))

--- a/qiskit_aqt_provider/test/fixtures.py
+++ b/qiskit_aqt_provider/test/fixtures.py
@@ -23,7 +23,9 @@ from qiskit.circuit import QuantumCircuit
 
 from qiskit_aqt_provider.aqt_provider import AQTProvider
 from qiskit_aqt_provider.aqt_resource import ApiResource, OfflineSimulatorResource
-from qiskit_aqt_provider.circuit_to_aqt import circuit_to_aqt_job
+from qiskit_aqt_provider.circuit_to_aqt import (
+    _qiskit_to_aqt_circuit,
+)
 
 
 class MockSimulator(OfflineSimulatorResource):
@@ -36,33 +38,36 @@ class MockSimulator(OfflineSimulatorResource):
             ApiResource(name="mock_simulator", id="mock_simulator", type="offline_simulator"),
         )
 
-        self.submit_call_args: List[Tuple[QuantumCircuit, int]] = []
+        self.submit_call_args: List[Tuple[List[QuantumCircuit], int]] = []
 
-    def submit(self, circuit: QuantumCircuit, shots: int) -> uuid.UUID:
-        """Submit the circuit for shots executions on the backend.
+    def submit(self, circuits: List[QuantumCircuit], shots: int) -> uuid.UUID:
+        """Submit the circuits for execution on the backend.
 
         Record the passed arguments in `submit_call_args`.
 
-        Try to convert the circuit to the AQT JSON wire format.
+        Try to convert the circuits to the AQT JSON wire format.
 
         Args:
-            circuit: the circuit to execute on the simulator
+            circuits: the circuits to execute on the simulator
             shots: number of repetitions.
 
         Raises:
-            ValueError: the circuit cannot be converted to the AQT JSON wire format.
+            ValueError: at least one circuit cannot be converted to the AQT JSON wire format.
         """
-        try:
-            _ = circuit_to_aqt_job(circuit, shots=shots)
-        except Exception as e:  # noqa: BLE001
-            raise ValueError("Circuit cannot be converted to AQT JSON format:\n{circuit}") from e
+        for circuit in circuits:
+            try:
+                _ = _qiskit_to_aqt_circuit(circuit)
+            except Exception as e:  # noqa: BLE001
+                raise ValueError(
+                    "Circuit cannot be converted to AQT JSON format:\n{circuit}"
+                ) from e
 
-        self.submit_call_args.append((circuit, shots))
-        return super().submit(circuit, shots)
+        self.submit_call_args.append((circuits, shots))
+        return super().submit(circuits, shots)
 
     @property
-    def submitted_circuits(self) -> List[QuantumCircuit]:
-        """Circuits passed to the resource for execution, in submission order."""
+    def submitted_circuits(self) -> List[List[QuantumCircuit]]:
+        """Circuit batches passed to the resource for execution, in submission order."""
         return [circuit for circuit, _ in self.submit_call_args]
 
 

--- a/test/test_circuit_to_aqt.py
+++ b/test/test_circuit_to_aqt.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019.
+# (C) Copyright IBM 2019, Alpine Quantum Technologies 2023
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,17 +14,24 @@
 from math import pi
 
 import pytest
+from pydantic import ValidationError
 from qiskit import QuantumCircuit
 
 from qiskit_aqt_provider import api_models
-from qiskit_aqt_provider.circuit_to_aqt import circuit_to_aqt_job
+from qiskit_aqt_provider.circuit_to_aqt import circuits_to_aqt_job
+
+
+def test_no_circuit() -> None:
+    """Cannot convert an empty list of circuits to an AQT job request."""
+    with pytest.raises(ValidationError):
+        circuits_to_aqt_job([], shots=1)
 
 
 def test_empty_circuit() -> None:
     """Circuits need at least one measurement operation."""
     qc = QuantumCircuit(1)
     with pytest.raises(ValueError):
-        circuit_to_aqt_job(qc, shots=1)
+        circuits_to_aqt_job([qc], shots=1)
 
 
 def test_just_measure_circuit() -> None:
@@ -37,14 +44,18 @@ def test_just_measure_circuit() -> None:
     expected = api_models.JobSubmission(
         job_type="quantum_circuit",
         label="qiskit",
-        payload=api_models.QuantumCircuit(
-            repetitions=shots,
-            number_of_qubits=1,
-            quantum_circuit=api_models.Circuit(__root__=[api_models.Operation.measure()]),
+        payload=api_models.QuantumCircuits(
+            circuits=[
+                api_models.QuantumCircuit(
+                    repetitions=shots,
+                    number_of_qubits=1,
+                    quantum_circuit=api_models.Circuit(__root__=[api_models.Operation.measure()]),
+                ),
+            ]
         ),
     )
 
-    result = circuit_to_aqt_job(qc, shots=shots)
+    result = circuits_to_aqt_job([qc], shots=shots)
 
     assert result == expected
 
@@ -57,22 +68,26 @@ def test_valid_circuit() -> None:
     qc.rxx(pi / 2, 0, 1)
     qc.measure_all()
 
-    result = circuit_to_aqt_job(qc, shots=1)
+    result = circuits_to_aqt_job([qc], shots=1)
 
     expected = api_models.JobSubmission(
         job_type="quantum_circuit",
         label="qiskit",
-        payload=api_models.QuantumCircuit(
-            number_of_qubits=2,
-            repetitions=1,
-            quantum_circuit=api_models.Circuit(
-                __root__=[
-                    api_models.Operation.r(theta=0.5, phi=0.0, qubit=0),
-                    api_models.Operation.rz(phi=0.2, qubit=1),
-                    api_models.Operation.rxx(theta=0.5, qubits=[0, 1]),
-                    api_models.Operation.measure(),
-                ]
-            ),
+        payload=api_models.QuantumCircuits(
+            circuits=[
+                api_models.QuantumCircuit(
+                    number_of_qubits=2,
+                    repetitions=1,
+                    quantum_circuit=api_models.Circuit(
+                        __root__=[
+                            api_models.Operation.r(theta=0.5, phi=0.0, qubit=0),
+                            api_models.Operation.rz(phi=0.2, qubit=1),
+                            api_models.Operation.rxx(theta=0.5, qubits=[0, 1]),
+                            api_models.Operation.measure(),
+                        ]
+                    ),
+                ),
+            ]
         ),
     )
 
@@ -87,8 +102,8 @@ def test_invalid_gates_in_circuit() -> None:
     qc.h(0)  # not an AQT-resource basis gate
     qc.measure_all()
 
-    with pytest.raises(ValueError):
-        circuit_to_aqt_job(qc, shots=1)
+    with pytest.raises(ValueError, match="not in basis gate set"):
+        circuits_to_aqt_job([qc], shots=1)
 
 
 def test_invalid_measurements() -> None:
@@ -99,8 +114,8 @@ def test_invalid_measurements() -> None:
     qc_invalid.r(pi / 2, 0.0, 1)
     qc_invalid.measure([1], [1])
 
-    with pytest.raises(ValueError):
-        circuit_to_aqt_job(qc_invalid, shots=1)
+    with pytest.raises(ValueError, match="at the end of the circuit"):
+        circuits_to_aqt_job([qc_invalid], shots=1)
 
     # same circuit as above, but with the measurements at the end is valid
     qc = QuantumCircuit(2, 2)
@@ -109,20 +124,70 @@ def test_invalid_measurements() -> None:
     qc.measure([0], [0])
     qc.measure([1], [1])
 
-    result = circuit_to_aqt_job(qc, shots=1)
+    result = circuits_to_aqt_job([qc], shots=1)
     expected = api_models.JobSubmission(
         job_type="quantum_circuit",
         label="qiskit",
-        payload=api_models.QuantumCircuit(
-            number_of_qubits=2,
-            repetitions=1,
-            quantum_circuit=api_models.Circuit(
-                __root__=[
-                    api_models.Operation.r(theta=0.5, phi=0.0, qubit=0),
-                    api_models.Operation.r(theta=0.5, phi=0.0, qubit=1),
-                    api_models.Operation.measure(),
-                ]
-            ),
+        payload=api_models.QuantumCircuits(
+            circuits=[
+                api_models.QuantumCircuit(
+                    number_of_qubits=2,
+                    repetitions=1,
+                    quantum_circuit=api_models.Circuit(
+                        __root__=[
+                            api_models.Operation.r(theta=0.5, phi=0.0, qubit=0),
+                            api_models.Operation.r(theta=0.5, phi=0.0, qubit=1),
+                            api_models.Operation.measure(),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    )
+
+    assert result == expected
+
+
+def test_convert_multiple_circuits() -> None:
+    """Convert multiple circuits. Check that the order is conserved."""
+    qc0 = QuantumCircuit(2)
+    qc0.r(pi / 2, 0.0, 0)
+    qc0.rxx(pi / 2, 0, 1)
+    qc0.measure_all()
+
+    qc1 = QuantumCircuit(1)
+    qc1.r(pi / 4, 0.0, 0)
+    qc1.measure_all()
+
+    result = circuits_to_aqt_job([qc0, qc1], shots=1)
+
+    expected = api_models.JobSubmission(
+        job_type="quantum_circuit",
+        label="qiskit",
+        payload=api_models.QuantumCircuits(
+            circuits=[
+                api_models.QuantumCircuit(
+                    number_of_qubits=2,
+                    repetitions=1,
+                    quantum_circuit=api_models.Circuit(
+                        __root__=[
+                            api_models.Operation.r(theta=0.5, phi=0.0, qubit=0),
+                            api_models.Operation.rxx(theta=0.5, qubits=[0, 1]),
+                            api_models.Operation.measure(),
+                        ]
+                    ),
+                ),
+                api_models.QuantumCircuit(
+                    number_of_qubits=1,
+                    repetitions=1,
+                    quantum_circuit=api_models.Circuit(
+                        __root__=[
+                            api_models.Operation.r(theta=0.25, phi=0.0, qubit=0),
+                            api_models.Operation.measure(),
+                        ]
+                    ),
+                ),
+            ],
         ),
     )
 

--- a/test/test_execution.py
+++ b/test/test_execution.py
@@ -23,7 +23,6 @@ from typing import List
 import numpy as np
 import pytest
 import qiskit
-from dirty_equals import IsUUID
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.providers.jobstatus import JobStatus
 from qiskit.result import Counts
@@ -85,8 +84,7 @@ def test_error_circuit() -> None:
 
     result = qiskit.execute(qc, backend).result()
     assert result.success is False
-    errors = list(result._metadata["errors"].items())
-    assert errors == [(IsUUID, backend.error_message)]
+    assert backend.error_message == result._metadata["error"]
 
 
 def test_cancelled_circuit() -> None:

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -127,7 +127,7 @@ def test_aqt_sampler_transpilation(theta: float, offline_simulator_no_noise: Moc
     # the sampler was only called once
     assert len(offline_simulator_no_noise.submitted_circuits) == 1
     # get the circuit passed to the backend
-    (transpiled_circuit,) = offline_simulator_no_noise.submitted_circuits
+    ((transpiled_circuit,),) = offline_simulator_no_noise.submitted_circuits
 
     # compare to the circuit obtained by binding the parameters and transpiling at once
     expected = qc.assign_parameters({theta_param: theta})

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import json
 import math
 import uuid
 from unittest import mock
@@ -141,6 +142,26 @@ def test_offline_simulator_invalid_api_resource() -> None:
         )
 
 
+def test_offline_simulator_invalid_job_id(offline_simulator_no_noise: MockSimulator) -> None:
+    """Check that the offline simulator raises UnknownJobError if the job id passed
+    to `result()` is invalid.
+    """
+    qc = QuantumCircuit(1)
+    qc.measure_all()
+
+    job = offline_simulator_no_noise.run([qc], shots=1)
+    job_id = uuid.UUID(hex=job.job_id())
+    invalid_job_id = uuid.uuid4()
+    assert invalid_job_id != job_id
+
+    with pytest.raises(api_models.UnknownJobError, match=str(invalid_job_id)):
+        offline_simulator_no_noise.result(invalid_job_id)
+
+    # querying the actual job is successful
+    result = offline_simulator_no_noise.result(job_id)
+    assert result.job.job_id == job_id
+
+
 def test_submit_valid_response(httpx_mock: HTTPXMock) -> None:
     """Check that AQTResource.submit passes the authorization token and
     extracts the correct job_id when the response payload is valid.
@@ -155,16 +176,18 @@ def test_submit_valid_response(httpx_mock: HTTPXMock) -> None:
 
         return httpx.Response(
             status_code=httpx.codes.OK,
-            json=api_models.Response.queued(
-                job_id=expected_job_id,
-                resource_id=backend._resource["id"],
-                workspace_id=backend._workspace,
-            ).json(),
+            json=json.loads(
+                api_models.Response.queued(
+                    job_id=expected_job_id,
+                    resource_id=backend._resource["id"],
+                    workspace_id=backend._workspace,
+                ).json()
+            ),
         )
 
     httpx_mock.add_callback(handle_submit, method="POST")
 
-    job_id = backend.submit(empty_circuit(2), shots=10)
+    job_id = backend.submit([empty_circuit(2)], shots=10)
     assert job_id == expected_job_id
 
 
@@ -176,7 +199,7 @@ def test_submit_bad_request(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(status_code=httpx.codes.BAD_REQUEST)
 
     with pytest.raises(httpx.HTTPError):
-        backend.submit(empty_circuit(2), shots=10)
+        backend.submit([empty_circuit(2)], shots=10)
 
 
 def test_result_valid_response(httpx_mock: HTTPXMock) -> None:
@@ -195,7 +218,7 @@ def test_result_valid_response(httpx_mock: HTTPXMock) -> None:
         assert request.headers["sdk"] == "qiskit"
         assert request.headers["authorization"] == f"Bearer {token}"
 
-        return httpx.Response(status_code=httpx.codes.OK, json=payload.json())
+        return httpx.Response(status_code=httpx.codes.OK, json=json.loads(payload.json()))
 
     httpx_mock.add_callback(handle_result, method="GET")
 
@@ -221,7 +244,7 @@ def test_result_unknown_job(httpx_mock: HTTPXMock) -> None:
     backend = DummyResource("")
     job_id = uuid.uuid4()
 
-    httpx_mock.add_response(json=api_models.Response.unknown_job(job_id=job_id).json())
+    httpx_mock.add_response(json=json.loads(api_models.Response.unknown_job(job_id=job_id).json()))
 
     with pytest.raises(api_models.UnknownJobError, match=str(job_id)):
         backend.result(job_id)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This patch adds support for the AQT cloud's server-side multi-circuit jobs.

All jobs are now submitted as multi-circuit jobs to the AQT cloud. An optional progress bar can be displayed while waiting for job completion.

### Details and comments

- with these changes, partial circuit results for a multi-circuits job are not accessible anymore. Either all the circuit executions succeed and all the results are returned, or at least one fails and the job errors with no results forwarded;
- the optional progress bar is enabled by default. The backend is provided by [`tqdm`](https://pypi.org/project/tqdm/). The switch (enabled by default) is an option named `with_progress_bar` in the backend;
- the `AQTSampler` implementation disables the progress bar by default;
- the Grover 3-SAT solver example is migrated to the `AQTSampler` to highlight its use-case;
- the default query interval (`query_period_seconds`) is reduced from 5 s to 1 s.
